### PR TITLE
Uses process.stdout.rows / columns to match size of app to terminal size

### DIFF
--- a/styleFile.js
+++ b/styleFile.js
@@ -7,4 +7,7 @@ module.exports = {
 
 	// setting for accent text and line colors
 	accentColor: 'red', // accepted values include ['red', 'blue', 'white', 'green', etc.]
+
+	// setting to determine whether app dynamically adjusts to screen resizing; setting to false may improve performance
+	appResize: true, // acepted values include [true, false]
 }

--- a/ui.js
+++ b/ui.js
@@ -21,7 +21,7 @@ const gitBranchVisualProcess = require('./actions/gitBranchVisualProcess')
 // const enterAltScreenCommand = "\x1b[?1049h";
 // const leaveAltScreenCommand = "\x1b[?1049l";
 
-const {showLogo, defaultColor, accentColor} = require('./styleFile')
+const {showLogo, defaultColor, accentColor, appResize} = require('./styleFile')
 
 // const exitFullScreen = () => {
 // 	process.stdout.write(leaveAltScreenCommand);
@@ -41,14 +41,11 @@ const App = () => {
 			setStatus(gitStatusPull());
 			setBranch(gitBranchCall());
 			setVisual(gitBranchVisualPull());
-			setHeight(process.stdout.rows)
+			if (appResize) {setHeight(process.stdout.rows)}
 			const { width, height } = measureElement(ref.current);
 			setWidth(width);
 		}, 1000);
-
-		// exitFullScreen();
-		// process.stdout.write(enterAltScreenCommand);
-
+		if (!appResize) {setHeight(process.stdout.rows)}
 
 		return () => {
 			clearInterval(intervalStatusCheck);
@@ -57,6 +54,7 @@ const App = () => {
 
 	const statusProcessed = gitStatusProcess(status)
 	const visualProcessed = gitBranchVisualProcess(visual)
+
 
 	return (
 		<Box flexDirection="column" minHeight={appheight}>

--- a/ui.js
+++ b/ui.js
@@ -18,20 +18,21 @@ const gitStatusProcess = require('./actions/gitStatusProcess')
 const gitBranchVisualPull = require('./actions/gitBranchVisualPull')
 const gitBranchVisualProcess = require('./actions/gitBranchVisualProcess')
 
-const enterAltScreenCommand = "\x1b[?1049h";
-const leaveAltScreenCommand = "\x1b[?1049l";
+// const enterAltScreenCommand = "\x1b[?1049h";
+// const leaveAltScreenCommand = "\x1b[?1049l";
 
 const {showLogo, defaultColor, accentColor} = require('./styleFile')
 
-const exitFullScreen = () => {
-	process.stdout.write(leaveAltScreenCommand);
-};
+// const exitFullScreen = () => {
+// 	process.stdout.write(leaveAltScreenCommand);
+// };
 
 const App = () => {
 	const [status, setStatus] = useState("");
 	const [branch, setBranch] = useState("");
 	const [visual, setVisual] = useState("");
 	const [appWidth, setWidth] = useState(null);
+	const [appheight, setHeight] = useState("50")
 
 	const ref = useRef(null);
 
@@ -40,12 +41,14 @@ const App = () => {
 			setStatus(gitStatusPull());
 			setBranch(gitBranchCall());
 			setVisual(gitBranchVisualPull());
+			setHeight(process.stdout.rows)
+			const { width, height } = measureElement(ref.current);
+			setWidth(width);
 		}, 1000);
 
-		exitFullScreen();
-		process.stdout.write(enterAltScreenCommand);
-		const { width, height } = measureElement(ref.current);
-		setWidth(width);
+		// exitFullScreen();
+		// process.stdout.write(enterAltScreenCommand);
+
 
 		return () => {
 			clearInterval(intervalStatusCheck);
@@ -56,7 +59,7 @@ const App = () => {
 	const visualProcessed = gitBranchVisualProcess(visual)
 
 	return (
-		<Box flexDirection="column">
+		<Box flexDirection="column" minHeight={appheight}>
 			{showLogo && <Logo />}
 			<Box
 				borderStyle="round"
@@ -125,6 +128,7 @@ const App = () => {
 				</Box>
 			</Box>
 			<Selector defaultColor={defaultColor} accentColor={accentColor} />
+			<Newline />
 		</Box>
 	);
 };

--- a/ui.js
+++ b/ui.js
@@ -18,14 +18,7 @@ const gitStatusProcess = require('./actions/gitStatusProcess')
 const gitBranchVisualPull = require('./actions/gitBranchVisualPull')
 const gitBranchVisualProcess = require('./actions/gitBranchVisualProcess')
 
-// const enterAltScreenCommand = "\x1b[?1049h";
-// const leaveAltScreenCommand = "\x1b[?1049l";
-
 const {showLogo, defaultColor, accentColor, appResize} = require('./styleFile')
-
-// const exitFullScreen = () => {
-// 	process.stdout.write(leaveAltScreenCommand);
-// };
 
 const App = () => {
 	const [status, setStatus] = useState("");


### PR DESCRIPTION
- Enables live re-sizing of terminal due to including on state and re-checking size every second.
- Hides any warnings that previously showed up due to app taking up full screen.
- Fixes issue with returning after viewing full git tree, due to app taking up full screen.
- May cause additional flickering due to re-rendering when entering content (e.g. entering a comment).
- May want to edit other components, e.g., git tree, to also use terminal height when rendering to fit full length